### PR TITLE
using useContext

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,22 @@
-import React from 'react';
+import React, { useContext } from 'react';
 
 import Ingredients from './components/Ingredients/Ingredients';
+import Auth from './components/Auth';
+
+/**
+ * review section 7 for an explanation about React Context
+ */
+import { AuthContext } from './context/auth-context'
 
 const App = props => {
-  return <Ingredients />;
+  const authContext = useContext(AuthContext);
+
+  let content = <Auth />
+  if( authContext.isAuth ) {
+    content = <Ingredients />
+  }
+
+  return content;
 };
 
 export default App;

--- a/src/components/Auth.js
+++ b/src/components/Auth.js
@@ -1,10 +1,16 @@
-import React from 'react';
+import React, { useContext } from 'react';
 
 import Card from './UI/Card';
 import './Auth.css';
 
+import { AuthContext } from '../context/auth-context'
+
 const Auth = props => {
-  const loginHandler = () => {};
+  const authContext = useContext(AuthContext);
+  console.log("what is in the authContext: ", authContext );
+  const loginHandler = () => {
+    authContext.login();
+  };
 
   return (
     <div className="auth">

--- a/src/context/auth-context.js
+++ b/src/context/auth-context.js
@@ -1,0 +1,24 @@
+import React, { useState } from 'react';
+
+export const AuthContext = React.createContext({
+    isAuth: false,
+    login: () => {}
+})
+
+const AuthContextProvider = (props) => {
+    const [ isAuth, setIsAuth ] = useState(false);
+
+    const loginHandler = () => {
+        setIsAuth(true);
+    }
+
+    return (
+        <AuthContext.Provider 
+        value={{login: loginHandler, isAuth }}
+        >
+            {props.children}
+        </AuthContext.Provider>
+    )
+}
+
+export default AuthContextProvider;

--- a/src/index.js
+++ b/src/index.js
@@ -3,5 +3,10 @@ import ReactDOM from 'react-dom';
 
 import './index.css';
 import App from './App';
+import AuthContextProvider from './context/auth-context';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+ReactDOM.render(
+    <AuthContextProvider>
+        <App />
+    </AuthContextProvider>, 
+    document.getElementById('root'));


### PR DESCRIPTION
useContext is a way to provide state that may be important in a number of different places in an app.

it wraps the <App> component and passes all the child props to the rest of the app.

In other places in the app, import the context named constant (AuthContext) as well as the useContext hook, make a new const for the context (const authContext) and assign a new useContext instance to it.

All the context values set up are exposed to be used or set depending on what needs to be done